### PR TITLE
Add no_std support

### DIFF
--- a/src/currency.rs
+++ b/src/currency.rs
@@ -1,4 +1,5 @@
-use std::str::FromStr;
+use alloc::str::FromStr;
+use alloc::string::String;
 
 /// Defines currencies
 ///

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -1,5 +1,9 @@
 use crate::{num2words::Num2Err, Currency, Language};
 use num_bigfloat::BigFloat;
+use alloc::string::String;
+use alloc::vec::Vec;
+use alloc::format;
+use alloc::vec;
 
 pub struct English {
     prefer_oh: bool,

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -1,5 +1,9 @@
 use crate::{num2words::Num2Err, Currency, Language};
 use num_bigfloat::BigFloat;
+use alloc::string::String;
+use alloc::vec::Vec;
+use alloc::format;
+use alloc::vec;
 
 pub struct French {
     feminine: bool,

--- a/src/lang/lang.rs
+++ b/src/lang/lang.rs
@@ -2,7 +2,10 @@ use crate::lang;
 use crate::num2words::Num2Err;
 use crate::Currency;
 use num_bigfloat::BigFloat;
-use std::str::FromStr;
+use alloc::str::FromStr;
+use alloc::string::String;
+use alloc::vec::Vec;
+use alloc::boxed::Box;
 
 /// Defines what is a language
 pub trait Language {

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -1,6 +1,10 @@
 use crate::{num2words::Num2Err, Currency, Language};
 use num_bigfloat::BigFloat;
-use std::str::FromStr;
+use alloc::str::FromStr;
+use alloc::string::String;
+use alloc::vec::Vec;
+use alloc::format;
+use alloc::vec;
 
 // Source: Ukrainian Orthography 2019 / Український Правопис 2019
 // § 38. Constructed numerals / Складні числівники

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 #![crate_type = "lib"]
 #![crate_name = "num2words"]
+#![no_std]
 
-/*!
+extern crate alloc;
+
+/**
  * Convert numbers like `42` to `forty-two`
  *
  * ## Usage

--- a/src/num2words.rs
+++ b/src/num2words.rs
@@ -1,5 +1,8 @@
 use crate::{lang, Currency, Lang, Output};
 use num_bigfloat::BigFloat;
+use alloc::string::String;
+use alloc::vec::Vec;
+use alloc::vec;
 
 /// Error type returned by the builder
 #[derive(Debug, PartialEq)]
@@ -75,8 +78,8 @@ pub enum Num2Err {
     InfiniteYear,
 }
 
-impl std::fmt::Display for Num2Err {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for Num2Err {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(
             f,
             "{}",

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use alloc::str::FromStr;
 
 /// Type of the output `num2words` give
 pub enum Output {


### PR DESCRIPTION
Hi there,

I'm working on a project to get an extremely minimal TTS working in Rust.
As part of the requirements, my library needs to be `#![no_std]`.
It'd be nice to take advantage of existing libraries; and yours is very easily adapted to `no_std`.
This makes that simple change. 

The only two future consideration are:

- anything that does depend on `std` will need to be behind a feature flag, and
- you may want to enable [`std_instead_of_alloc`](https://rust-lang.github.io/rust-clippy/master/index.html#/std_instead_of_alloc); this will suggest that any imports from `std::` be changed to `alloc::` where possible.

Thanks for putting in the hard work for this!
